### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/services.rs
+++ b/src/services.rs
@@ -23,7 +23,7 @@ Weather in {} (latitude: {}, longitude: {}): {} {}
 > Temperature: {:.1}°C,
 > Humidity: {:.1}%,
 > Pressure: {:.1} hPa,
-> Wind Speed: {:.} m/s
+> Wind Speed: {} m/s
 "#, 
             response.name, lat, lon, description, get_temperature_imoji(temperature), temperature,
             humidity, pressure,wind_speed


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.